### PR TITLE
Match. Added selection certificate and P12 key by ENV MATCH_CERTIFICATE_ID

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -4,6 +4,7 @@ require 'credentials_manager/appfile_config'
 require_relative 'module'
 
 module Match
+  # rubocop:disable Metrics/ClassLength
   class Options
     # This is match specific, as users can append storage specific options
     def self.append_option(option)
@@ -268,6 +269,11 @@ module Match
                                      description: "Include all matching certificates in the provisioning profile. Works only for the 'development' provisioning profile type",
                                      type: Boolean,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :certificate_id,
+                                     env_name: "MATCH_CERTIFICATE_ID",
+                                     description: "Selects needed certificate by id. Useful if multiple certificates are stored in one place",
+                                     type: String,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :force_for_new_certificates,
                                      env_name:  "MATCH_FORCE_FOR_NEW_CERTIFICATES",
                                      description: "Renew the provisioning profiles if the certificate count on the developer portal has changed. Works only for the 'development' provisioning profile type. Requires 'include_all_certificates' option to be 'true'",

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -271,7 +271,7 @@ module Match
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :certificate_id,
                                      env_name: "MATCH_CERTIFICATE_ID",
-                                     description: "Selects needed certificate by id. Useful if multiple certificates are stored in one place",
+                                     description: "Select certificate by id. Useful if multiple certificates are stored in one place",
                                      type: String,
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :force_for_new_certificates,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -220,8 +220,8 @@ module Match
 
     # @return [String] Path to certificate or P12 key
     def select_cert_or_key(paths:)
-      matching_path = ENV['MATCH_CERTIFICATE_ID'] ? paths.find { |path| path.include?(ENV['MATCH_CERTIFICATE_ID']) } : nil
-      matching_path || paths.last
+      cert_id_path = ENV['MATCH_CERTIFICATE_ID'] ? paths.find { |path| path.include?(ENV['MATCH_CERTIFICATE_ID']) } : nil
+      cert_id_path || paths.last
     end
 
     # rubocop:disable Metrics/PerceivedComplexity

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -175,7 +175,7 @@ module Match
         self.files_to_commit << cert_path
         self.files_to_commit << private_key_path
       else
-        cert_path = certs.last
+        cert_path = select_cert_or_key(paths: certs)
 
         # Check validity of certificate
         if Utils.is_cert_valid?(cert_path)
@@ -199,7 +199,7 @@ module Match
             # Import the private key
             # there seems to be no good way to check if it's already installed - so just install it
             # Key will only be added to the partition list if it isn't already installed
-            Utils.import(keys.last, params[:keychain_name], password: params[:keychain_password])
+            Utils.import(select_cert_or_key(paths: keys), params[:keychain_name], password: params[:keychain_password])
           end
         else
           UI.message("Skipping installation of certificate as it would not work on this operating system.")
@@ -207,7 +207,7 @@ module Match
 
         if params[:output_path]
           FileUtils.cp(cert_path, params[:output_path])
-          FileUtils.cp(keys.last, params[:output_path])
+          FileUtils.cp(select_cert_or_key(paths: keys), params[:output_path])
         end
 
         # Get and print info of certificate
@@ -216,6 +216,12 @@ module Match
       end
 
       return File.basename(cert_path).gsub(".cer", "") # Certificate ID
+    end
+
+    # @return [String] Path to certificate or P12 key
+    def select_cert_or_key(paths:)
+      matching_path = ENV['MATCH_CERTIFICATE_ID'] ? paths.find { |path| path.include?(ENV['MATCH_CERTIFICATE_ID']) } : nil
+      matching_path || paths.last
     end
 
     # rubocop:disable Metrics/PerceivedComplexity


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
#### Why is change required?
Now match can only work with one (last without sort) certificate for the apple development team, which is stored in one git branch.

The changes are needed in order to be able to implement the case of seamless renewal of certificates and then profiles that are in the same team:

1. Create a new distribution signing certificate (the old certificate remains in the match git repo and on the apple portal)
2. Put the signing certificate in the match git repo, next to the old one
3. Specify MATCH_CERTIFICATE_ID in a project that already wants to use the new certificate from match git repo
4. Update profiles on the project with MATCH_CERTIFICATE_ID at ENV

This way - applications can start seamlessly switching to a new signing certificate (because the old signing certificate remains both on the portal and in the match git repo)


#### What problem is being solved?
We can choose which signing certificate is used when updating profiles

Because now the latest certificate and p12 key are always used without sorting in
[`fastlane/match/lib/match/runner.rb`](https://github.com/fastlane/fastlane/blob/600555cfcdb2eb6423ce4050428bda4f7812534f/match/lib/match/runner.rb#L163)

```
def fetch_certificate(params: nil, working_directory: nil, specific_cert_type: nil)
  ...
  certs = Dir[File.join(prefixed_working_directory, "certs", cert_type.to_s, "*.cer")]
  keys = Dir[File.join(prefixed_working_directory, "certs", cert_type.to_s, "*.p12")]
    ...
    cert_path = certs.last
    ...
    Utils.import(keys.last, params[:keychain_name], password: params[:keychain_password])
    ...
    FileUtils.cp(keys.last, params[:output_path])
    ...
end
```
 
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
Added ENV variable `MATCH_CERTIFICATE_ID` which allows you to select a signing certificate and P12 key for it by certificate ID

This revision is needed for the gradual transition of applications to a new signing certificate (without revoking the old one)

<!-- Please describe in detail how you tested your changes. -->
#### Description of the test case:
1. Match git repo stores distribution signing certificate created in 2022
2. The project uses
3. Put in the match git repo the distribution certificate, the signing certificate created in 2023
4. Specify MATCH_CERTIFICATE_ID in fastlane/.env of the certificate created in 2023 (fresh)
5. Update profiles via match
6. I check that the certificate created in 2023 is used)

<!-- ### Testing Steps -->
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
